### PR TITLE
Add a dumb yet effective complex analysis

### DIFF
--- a/frontend_mess/analyses/__init__.py
+++ b/frontend_mess/analyses/__init__.py
@@ -7,6 +7,11 @@ def get_count_generics():
     from frontend_mess.analyses.count_generics import CountGenerics
     return CountGenerics
 
+def get_linalg_analysis():
+    from frontend_mess.analyses.linalg_analysis import LinalgAnalysis
+    return LinalgAnalysis
+
 
 def get_all_analyses() -> dict[str, Callable[[], type[ModuleAnalysis]]]:
-    return {"count_generics": get_count_generics}
+    return {"count_generics": get_count_generics,
+            "linalg_analysis": get_linalg_analysis}

--- a/frontend_mess/analyses/linalg_analysis.py
+++ b/frontend_mess/analyses/linalg_analysis.py
@@ -1,0 +1,58 @@
+from collections import Counter
+from frontend_mess.analyses.analysis import ModuleAnalysis
+from xdsl.context import Context
+from xdsl.dialects import builtin, linalg
+from pprint import pprint
+from xdsl.printer import Printer
+from io import StringIO
+
+class LinalgAnalysis(ModuleAnalysis):
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        """
+        This is a simple analysis that tries to see how similar linalg
+        generics are by looking at how their strings are printed.
+        """
+        map_keeper : list[str] = [] 
+        iterator_keeper : list[str] = [] 
+        body_keeper : list[str] = []
+        body_ops_keeper : list[str] = []
+        for operation in op.walk():
+            if isinstance(operation, linalg.GenericOp):
+                # Keep linalg generic indexing maps
+
+                map_keeper.append(str(operation.indexing_maps))
+
+                # Keep linalg generic iterators
+                
+                iterator_keeper.append(str(operation.iterator_types))
+
+                # Compare linalg generic body's (full body)
+
+                # Create entirely new stream and Printer
+                string_stream = StringIO()
+                p = Printer(stream=string_stream, print_generic_format=True)
+                # Remove SSAValue name hints to allow similarity check
+                for block_arg in operation.body.block.args:
+                    block_arg.name_hint = None
+                p.print(operation.body.block)
+                body_keeper.append(string_stream.getvalue())
+
+
+                # Compare linalg generic body's (individual ops)
+
+                for body_op in operation.body.block.ops:
+                    # Get another fresh printer
+                    string_stream = StringIO()
+                    p = Printer(stream=string_stream, print_generic_format=True)
+                    p.print(body_op)
+                    body_ops_keeper.append(string_stream.getvalue())
+
+                # Count all unique occurences with str's __hash__ and store counts
+
+        pprint(Counter(map_keeper))
+        pprint(Counter(iterator_keeper))
+        pprint(Counter(body_keeper))
+        pprint(Counter(body_ops_keeper))
+
+
+

--- a/frontend_mess/analyses/linalg_analysis.py
+++ b/frontend_mess/analyses/linalg_analysis.py
@@ -4,7 +4,9 @@ from xdsl.context import Context
 from xdsl.dialects import builtin, linalg
 from pprint import pprint
 from xdsl.printer import Printer
+from xdsl.ir import Operation
 from io import StringIO
+import pandas as pd
 
 class LinalgAnalysis(ModuleAnalysis):
     def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
@@ -12,12 +14,18 @@ class LinalgAnalysis(ModuleAnalysis):
         This is a simple analysis that tries to see how similar linalg
         generics are by looking at how their strings are printed.
         """
+        amount_of_generics = 0
         map_keeper : list[str] = [] 
         iterator_keeper : list[str] = [] 
+        types_keeper : list[str] = [] 
+        element_types_keeper : list[str] = [] 
         body_keeper : list[str] = []
         body_ops_keeper : list[str] = []
         for operation in op.walk():
             if isinstance(operation, linalg.GenericOp):
+                # Count number of linalgs
+                amount_of_generics += 1
+
                 # Keep linalg generic indexing maps
 
                 map_keeper.append(str(operation.indexing_maps))
@@ -26,33 +34,63 @@ class LinalgAnalysis(ModuleAnalysis):
                 
                 iterator_keeper.append(str(operation.iterator_types))
 
+                # Keep linalg generic operand types 
+
+                types_keeper.extend([str(oper.type) for oper in operation.operands])
+
+                # Keep linalg generic element types
+
+                for operand in operation.operands:
+                    if isinstance(operand.type, builtin.TensorType):
+                        element_types_keeper.append(str(operand.type.element_type))
+                    else:
+                        element_types_keeper.append(str(operand.type))
+
                 # Compare linalg generic body's (full body)
 
-                # Create entirely new stream and Printer
-                string_stream = StringIO()
-                p = Printer(stream=string_stream, print_generic_format=True)
                 # Remove SSAValue name hints to allow similarity check
                 for block_arg in operation.body.block.args:
                     block_arg.name_hint = None
-                p.print(operation.body.block)
-                body_keeper.append(string_stream.getvalue())
+                body_keeper.append(print_fallback(operation.body.block))
 
 
                 # Compare linalg generic body's (individual ops)
 
                 for body_op in operation.body.block.ops:
-                    # Get another fresh printer
-                    string_stream = StringIO()
-                    p = Printer(stream=string_stream, print_generic_format=True)
-                    p.print(body_op)
-                    body_ops_keeper.append(string_stream.getvalue())
+                    body_ops_keeper.append(print_fallback(body_op))
 
                 # Count all unique occurences with str's __hash__ and store counts
+        keepers = [map_keeper, iterator_keeper, types_keeper, 
+                   element_types_keeper, body_keeper, body_ops_keeper]
+        counters = [Counter(keeper) for keeper in keepers]
+        names = ["maps", "iterators", "operand types","element types","bodies", "body ops"]
+        unique_lens = []
+        for counter,name in zip(counters,names):
+            print("="*19)
+            print(name)
+            print("="*19)
+            for key, val in sorted(counter.items(), key=lambda x : x[1], reverse=True):
+                print(f"\033[1m\033[4m{val:^3}\033[0m → {key}")
+            unique_lens.append(len(counter))
+        print("="*19)
+        print(" Analysis Overview ")
+        print("="*19)
+        print(f"Linalg generics      : {amount_of_generics}")
+        for name, number in zip(names, unique_lens, strict=True):
+            print(f"Unique {name:13} : {number}")
 
-        pprint(Counter(map_keeper))
-        pprint(Counter(iterator_keeper))
-        pprint(Counter(body_keeper))
-        pprint(Counter(body_ops_keeper))
-
-
+def print_fallback(print_input) -> str:
+    try:
+        # Create entirely new stream and Printer on purpose
+        string_stream = StringIO()
+        p = Printer(stream=string_stream, print_generic_format=False)
+        p.print(print_input)
+        return string_stream.getvalue()
+    #something went wrong during printing, fall back to generic printer
+    except: 
+        # The old stream has to be discarded, create a new one
+        g_string_stream = StringIO()
+        gp = Printer(stream=g_string_stream, print_generic_format=True)
+        gp.print(print_input)
+        return g_string_stream.getvalue()
 

--- a/tests/filecheck/examples/nnmodule.txt
+++ b/tests/filecheck/examples/nnmodule.txt
@@ -1,0 +1,62 @@
+// RUN: python examples/nnmodule.py | mlir-opt --linalg-generalize-named-ops --mlir-print-op-generic --canonicalize |  mess-analysis linalg_analysis --allow-unregistered-dialect | sed 's/\x1B\[[0-9;]*[mK]//g' | filecheck %s
+// CHECK:===================
+// CHECK:maps
+// CHECK:===================
+// CHECK: 1  → [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>]
+// CHECK: 1  → [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>]
+// CHECK: 1  → [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>]
+// CHECK:===================
+// CHECK:iterators
+// CHECK:===================
+// CHECK: 1  → [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>]
+// CHECK: 1  → [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
+// CHECK: 1  → [#linalg.iterator_type<parallel>]
+// CHECK:===================
+// CHECK:operand types
+// CHECK:===================
+// CHECK: 3  → tensor<3xf32>
+// CHECK: 2  → tensor<1x3xf32>
+// CHECK: 1  → f32
+// CHECK: 1  → tensor<1x4xf32>
+// CHECK: 1  → tensor<4x3xf32>
+// CHECK:===================
+// CHECK:element types
+// CHECK:===================
+// CHECK: 8  → f32
+// CHECK:===================
+// CHECK:bodies
+// CHECK:===================
+// CHECK: 1  →
+// CHECK:^0(%0 : f32, %1 : f32):
+// CHECK:  linalg.yield %0 : f32
+//
+// CHECK: 1  →
+// CHECK:^0(%0 : f32, %1 : f32, %2 : f32):
+// CHECK:  %3 = arith.mulf %0, %1 : f32
+// CHECK:  %4 = arith.addf %2, %3 : f32
+// CHECK:  linalg.yield %4 : f32
+//
+// CHECK: 1  →
+// CHECK:^0(%0 : f32, %1 : f32, %2 : f32):
+// CHECK:  %3 = arith.addf %0, %1 : f32
+// CHECK:  linalg.yield %3 : f32
+//
+// CHECK:===================
+// CHECK:body ops
+// CHECK:===================
+// CHECK: 3  → linalg.yield %0 : f32
+//
+// CHECK: 2  → %0 = arith.addf %1, %2 : f32
+//
+// CHECK: 1  → %0 = arith.mulf %1, %2 : f32
+//
+// CHECK:===================
+// CHECK: Analysis Overview
+// CHECK:===================
+// CHECK:Linalg generics      : 3
+// CHECK:Unique maps          : 3
+// CHECK:Unique iterators     : 3
+// CHECK:Unique operand types : 5
+// CHECK:Unique element types : 1
+// CHECK:Unique bodies        : 3
+// CHECK:Unique body ops      : 3

--- a/tests/filecheck/examples/overview_berttiny.txt
+++ b/tests/filecheck/examples/overview_berttiny.txt
@@ -1,0 +1,11 @@
+// RUN: python examples/transformers_berttiny.py | mlir-opt --linalg-generalize-named-ops --mlir-print-op-generic --canonicalize |  mess-analysis linalg_analysis --allow-unregistered-dialect | filecheck %s
+// CHECK: ===================
+// CHECK:  Analysis Overview
+// CHECK: ===================
+// CHECK: Linalg generics      : 202
+// CHECK: Unique maps          : 26
+// CHECK: Unique iterators     : 6
+// CHECK: Unique operand types : 39
+// CHECK: Unique element types : 4
+// CHECK: Unique bodies        : 30
+// CHECK: Unique body ops      : 33

--- a/tests/filecheck/examples/overview_resnet.txt
+++ b/tests/filecheck/examples/overview_resnet.txt
@@ -1,0 +1,12 @@
+// RUN: python examples/torchvision_resnet.py | mlir-opt --linalg-generalize-named-ops --mlir-print-op-generic --canonicalize |  mess-analysis linalg_analysis --allow-unregistered-dialect | filecheck %s
+// CHECK: ===================
+// CHECK:  Analysis Overview
+// CHECK: ===================
+// CHECK: Linalg generics      : 200
+// CHECK: Unique maps          : 15
+// CHECK: Unique iterators     : 7
+// CHECK: Unique operand types : 38
+// CHECK: Unique element types : 1
+// CHECK: Unique bodies        : 12
+// CHECK: Unique body ops      : 12
+

--- a/tests/filecheck/examples/overview_tinystories.txt
+++ b/tests/filecheck/examples/overview_tinystories.txt
@@ -1,0 +1,11 @@
+// RUN: python examples/transformers_tinystories.py | mlir-opt --linalg-generalize-named-ops --mlir-print-op-generic --canonicalize |  mess-analysis linalg_analysis --allow-unregistered-dialect | filecheck %s
+// CHECK: ===================
+// CHECK:  Analysis Overview
+// CHECK: ===================
+// CHECK: Linalg generics      : 608
+// CHECK: Unique maps          : 29
+// CHECK: Unique iterators     : 7
+// CHECK: Unique operand types : 40
+// CHECK: Unique element types : 4
+// CHECK: Unique bodies        : 34
+// CHECK: Unique body ops      : 35

--- a/tests/filecheck/examples/overview_whispersmall.txt
+++ b/tests/filecheck/examples/overview_whispersmall.txt
@@ -1,0 +1,11 @@
+// RUN: python examples/transformers_whispersmall.py | mlir-opt --linalg-generalize-named-ops --mlir-print-op-generic --canonicalize |  mess-analysis linalg_analysis --allow-unregistered-dialect | filecheck %s
+// CHECK: ===================
+// CHECK:  Analysis Overview
+// CHECK: ===================
+// CHECK: Linalg generics      : 832
+// CHECK: Unique maps          : 29
+// CHECK: Unique iterators     : 7
+// CHECK: Unique operand types : 39
+// CHECK: Unique element types : 4
+// CHECK: Unique bodies        : 32
+// CHECK: Unique body ops      : 34

--- a/tests/filecheck/lit.cfg
+++ b/tests/filecheck/lit.cfg
@@ -6,4 +6,4 @@ frontend_mess_src = os.path.dirname(os.path.dirname(config.test_source_root))
 
 config.name = "MESS"
 config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {frontend_mess_src}"])
-config.suffixes = ['.mlir']
+config.suffixes = ['.mlir', '.txt']


### PR DESCRIPTION
```
(frontend-mess) ❯ python examples/torchvision_resnet.py | mlir-opt --linalg-generalize-named-ops --mlir-print-op-generic --canonicalize |  mess-analysis linalg_analysis --allow-unregistered-dialect
===================
maps
===================
80  → [affine_map<(d0, d1, d2, d3) -> (0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d1, 0, 0)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>]
60  → [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>]
17  → [affine_map<(d0, d1, d2, d3) -> (0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>]
13  → [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, (d2 + d5), (d3 + d6))>, affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>, affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>]
 8  → [affine_map<(d0, d1, d2, d3) -> (0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>]
 7  → [affine_map<(d0, d1, d2, d3) -> ()>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>]
 7  → [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d4, ((d2 * 2) + d5), ((d3 * 2) + d6))>, affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d4, d5, d6)>, affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>]
 1  → [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, ((d2 * 2) + d4), ((d3 * 2) + d5))>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d4, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>]
 1  → [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, 0, 0)>]
 1  → [affine_map<(d0, d1, d2, d3) -> (0, d1, 0, 0)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>]
 1  → [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0, d1)>]
 1  → [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>]
 1  → [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>]
 1  → [affine_map<(d0, d1) -> (0, d1)>, affine_map<(d0, d1) -> (d0, d1)>]
 1  → [affine_map<(d0, d1) -> (0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>]
===================
iterators
===================
113 → [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>]
60  → [#linalg.iterator_type<parallel>]
20  → [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
 4  → [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>]
 1  → [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
 1  → [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>, #linalg.iterator_type<reduction>]
 1  → [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]
===================
operand types
===================
61  → tensor<1x128x28x28xf32>
61  → tensor<1x256x14x14xf32>
61  → tensor<1x512x7x7xf32>
54  → tensor<1x64x56x56xf32>
30  → tensor<64xf32>
30  → tensor<128xf32>
30  → tensor<256xf32>
30  → tensor<512xf32>
20  → tensor<64x1x1xf32>
20  → tensor<128x1x1xf32>
20  → tensor<256x1x1xf32>
20  → tensor<512x1x1xf32>
12  → tensor<1x64x112x112xf32>
 8  → f32
 6  → tensor<1x1000xf32>
 5  → tensor<1x64x58x58xf32>
 4  → tensor<64x64x3x3xf32>
 4  → tensor<1x128x30x30xf32>
 4  → tensor<1x256x16x16xf32>
 4  → tensor<1x512x1x1xf32>
 3  → tensor<128x128x3x3xf32>
 3  → tensor<256x256x3x3xf32>
 3  → tensor<1x512x9x9xf32>
 3  → tensor<512x512x3x3xf32>
 2  → tensor<512x1000xf32>
 1  → tensor<1x3x230x230xf32>
 1  → tensor<64x3x7x7xf32>
 1  → tensor<1x64x114x114xf32>
 1  → tensor<3x3xf32>
 1  → tensor<128x64x3x3xf32>
 1  → tensor<128x64x1x1xf32>
 1  → tensor<256x128x3x3xf32>
 1  → tensor<256x128x1x1xf32>
 1  → tensor<512x256x3x3xf32>
 1  → tensor<512x256x1x1xf32>
 1  → tensor<1000x512xf32>
 1  → tensor<1x512xf32>
 1  → tensor<1000xf32>
===================
element types
===================
511 → f32
===================
bodies
===================
40  →
^0(%0 : f32, %1 : f32, %2 : f32):
  %3 = arith.mulf %0, %1 : f32
  linalg.yield %3 : f32

29  →
^0(%0 : f32, %1 : f32, %2 : f32):
  %3 = arith.addf %0, %1 : f32
  linalg.yield %3 : f32

21  →
^0(%0 : f32, %1 : f32, %2 : f32):
  %3 = arith.mulf %0, %1 : f32
  %4 = arith.addf %2, %3 : f32
  linalg.yield %4 : f32

20  →
^0(%0 : f32, %1 : f32):
  %2 = arith.truncf %3 : f64 to f32
  %4 = arith.addf %0, %2 : f32
  linalg.yield %4 : f32

20  →
^0(%0 : f32, %1 : f32):
  %2 = math.sqrt %0 fastmath<none> : f32
  linalg.yield %2 : f32

20  →
^0(%0 : f32, %1 : f32):
  %2 = "arith.cmpf"(%0, %3) <{fastmath = #arith.fastmath<none>, predicate = 6 : i64}> : (f32, f32) -> i1
  "cf.assert"(%2) <{msg = "unimplemented: tensor with zero element"}> : (i1) -> ()
  %4 = "arith.divf"(%5, %0) <{fastmath = #arith.fastmath<none>}> : (f32, f32) -> f32
  "linalg.yield"(%4) : (f32) -> ()

20  →
^0(%0 : f32, %1 : f32, %2 : f32):
  %3 = arith.subf %0, %1 : f32
  linalg.yield %3 : f32

17  →
^0(%0 : f32, %1 : f32):
  %2 = arith.cmpf ugt, %0, %3 : f32
  %4 = arith.select %2, %0, %3 : f32
  linalg.yield %4 : f32

10  →
^0(%0 : f32, %1 : f32):
  linalg.yield %0 : f32

 1  →
^0(%0 : f32, %1 : f32, %2 : f32):
  %3 = arith.maximumf %2, %0 : f32
  linalg.yield %3 : f32

 1  →
^0(%0 : f32, %1 : f32):
  %2 = arith.addf %0, %1 : f32
  linalg.yield %2 : f32

 1  →
^0(%0 : f32, %1 : f32):
  %2 = arith.divf %0, %3 : f32
  linalg.yield %2 : f32

===================
body ops
===================
200 → linalg.yield %0 : f32

71  → %0 = arith.addf %1, %2 : f32

61  → %0 = arith.mulf %1, %2 : f32

21  → %0 = arith.divf %1, %2 : f32

20  → %0 = arith.truncf %1 : f64 to f32

20  → %0 = math.sqrt %1 fastmath<none> : f32

20  → %0 = arith.cmpf one, %1, %2 : f32

20  → "cf.assert"(%0) <{msg = "unimplemented: tensor with zero element"}> : (i1) -> ()

20  → %0 = arith.subf %1, %2 : f32

17  → %0 = arith.cmpf ugt, %1, %2 : f32

17  → %0 = arith.select %1, %2, %3 : f32

 1  → %0 = arith.maximumf %1, %2 : f32

===================
 Analysis Overview
===================
Linalg generics      : 200
Unique maps          : 15
Unique iterators     : 7
Unique operand types : 38
Unique element types : 1
Unique bodies        : 12
Unique body ops      : 12
```